### PR TITLE
Support variable length for InterfaceName in IPFIX string elements

### DIFF
--- a/example/SampleExporter/Program.cs
+++ b/example/SampleExporter/Program.cs
@@ -24,6 +24,7 @@ namespace Rubenhak.SampleExporter
                     .Field(FieldType.Protocol, 1)
                     .Field(FieldType.InputBytes, 4)
                     .Field(FieldType.InputPackets, 4)
+                    .Field(FieldType.InterfaceName, 65535)
                     ;
 
             var templateData = 
@@ -34,7 +35,8 @@ namespace Rubenhak.SampleExporter
                        (ushort)21,
                        (byte)ProtocolType.Tcp,
                        (UInt32)20*1024,
-                       (UInt32)20
+                       (UInt32)20,
+                       (string)"eni-00d32bc226162f669"
                       )
                 .Data(IPAddress.Parse("192.168.10.67"),
                        IPAddress.Parse("10.12.13.14"),
@@ -42,7 +44,8 @@ namespace Rubenhak.SampleExporter
                        (ushort)21,
                        (byte)ProtocolType.Tcp,
                        (UInt32)15 * 1024,
-                       (UInt32)15
+                       (UInt32)15,
+                       (string)"eni-00d32bc226162f669"
                       )
                       ;
 

--- a/src/NetflowExporter/BitConverterEx.cs
+++ b/src/NetflowExporter/BitConverterEx.cs
@@ -34,13 +34,43 @@ namespace Rubenhak.NetflowExporter
 
                 case TypeCode.String:
                     {
-                        if (((string)value).Length > field.Size)
+                        //if (((string)value).Length > field.Size)
+                        //{
+                        //    throw new ArgumentException("Provided string is too long.");
+                        //}
+                        //byte[] data = new byte[field.Size];
+                        //var charData = ((string)value).ToCharArray();
+                        //Buffer.BlockCopy(charData, 0, data, 0, Math.Min(charData.Length, data.Length));
+                        //return data;
+
+                        var length = (ushort)((string)value).Length;
+                        if (length > field.Size)
                         {
-                            throw new ArgumentException("Provided string is too long.");
+                            throw new ArgumentException($"Invalid length of string:{length} expected:{field.Size}");
                         }
-                        byte[] data = new byte[field.Size];
-                        var charData = ((string)value).ToCharArray();
-                        Buffer.BlockCopy(charData, 0, data, 0, Math.Min(charData.Length, data.Length));
+
+                        byte[] data = new byte[field.Size == 65535 ? length + 1 : field.Size];
+                        var charData = System.Text.Encoding.ASCII.GetBytes((string)value);
+
+                        if (field.Size == 65535)
+                        {
+                            /*
+                             65535 is used to designate a variable length element, which stores its length as the first
+                             byte of the element value.  This is required for fields such as 82, InterfaceName
+                             See: https://tools.ietf.org/html/rfc7011#section-7 for more details
+                            */
+
+                            // copy the length of the string as the first element
+                            var lengthBytes = BitConverter.GetBytes(length);
+                            Buffer.BlockCopy(lengthBytes, 0, data, 0, lengthBytes.Length);
+                            Buffer.BlockCopy(charData, 0, data, 0, Math.Min(charData.Length, data.Length));
+                        }
+                        else
+                        {
+                            // treat elements that do not have a size of 65535 as non-variable
+                            Buffer.BlockCopy(charData, 0, data, 0, Math.Min(charData.Length, data.Length) * sizeof(ushort));
+                        }
+
                         return data;
                     }
 


### PR DESCRIPTION
As discussed `InterfaceName` is not being parsed in SIEM (IBM QRadar). 

Have done changes as per below. Still not being able to parse. Using another library [python-ipfix](https://github.com/britram/python-ipfix#python-ipfix) which is written in python, I am able to parse `InterfaceName`

 https://tools.ietf.org/html/rfc7011#section-7 

```
In the Template Set, the Information Element Field Length is recorded as 65535.  This reserved length value notifies the Collecting Process that the length value of the Information Element will be carried in the Information Element content itself.
```
